### PR TITLE
feat: glassy artifact loading and neuromorphic buttons

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -6,11 +6,12 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils/index'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-xl text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        default:
+          'bg-white/10 text-white shadow-[inset_2px_2px_4px_rgba(255,255,255,0.2),inset_-2px_-2px_4px_rgba(0,0,0,0.2),0_8px_16px_rgba(0,0,0,0.15)] backdrop-blur-lg hover:bg-white/20 hover:shadow-[inset_1px_1px_2px_rgba(255,255,255,0.3),inset_-1px_-1px_2px_rgba(0,0,0,0.25),0_12px_24px_rgba(0,0,0,0.2)]',
         destructive:
           'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline:
@@ -22,9 +23,9 @@ const buttonVariants = cva(
       },
       size: {
         default: 'h-10 px-4 py-2',
-        sm: 'h-9 rounded-md px-3',
-        lg: 'h-11 rounded-md px-8',
-        icon: 'h-10 w-10'
+        sm: 'h-9 rounded-xl px-3',
+        lg: 'h-11 rounded-xl px-8',
+        icon: 'h-10 w-10 rounded-xl'
       }
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary
- add spinner overlay and liquid-glass styling to artifact dock
- introduce neuromorphic glass buttons for a sleeker UI

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bf84f8417083318340af6177e445a3