### PR TITLE
Refine header design

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -138,7 +138,7 @@
     @apply rounded-2xl border border-white/10 bg-white/5 backdrop-blur;
   }
   .glass-header {
-    @apply sticky top-0 z-30 backdrop-blur bg-black/30 border-b border-white/10;
+    @apply sticky top-0 z-50 backdrop-blur bg-black/40 border-b border-emerald-500/20 shadow-[0_0_15px_rgba(16,185,129,0.15)];
   }
   .chip {
     @apply rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-[11px] text-emerald-300 uppercase tracking-wide;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -99,13 +99,6 @@ export default async function RootLayout({
           className="pointer-events-none fixed inset-0 -z-10 [mask-image:radial-gradient(50%_50%_at_50%_50%,black,transparent)]"
         />
 
-        {/* Tasteful capability badge (can remove anytime) */}
-        <div className="pointer-events-none fixed inset-x-0 top-0 z-40 flex justify-center">
-          <div className="pointer-events-auto mt-4 rounded-full border border-emerald-500/30 bg-black/60 px-3 py-1 text-[11px] uppercase tracking-wide text-emerald-300 backdrop-blur">
-            ZEN Edge • Multi-Model • Search-Grounded • Edge Streaming
-          </div>
-        </div>
-
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -22,7 +22,7 @@ export const Header: React.FC<HeaderProps> = ({ user }) => {
     <header
       className={cn(
         // liquid-glass header (uses your globals.css helpers)
-        'glass-header z-30 px-4 py-2 flex items-center justify-between transition-[width] duration-200 ease-linear',
+        'glass-header px-4 py-2 flex items-center justify-between transition-[width] duration-200 ease-linear',
         open ? 'md:w-[calc(100%-var(--sidebar-width))]' : 'md:w-full',
         'w-full'
       )}
@@ -49,15 +49,15 @@ export const Header: React.FC<HeaderProps> = ({ user }) => {
 
       {/* Right: capability chips + auth menu */}
       <div className="flex items-center gap-4">
-        {/* liquid-glass chips (hidden on small screens) */}
-        <div className="hidden md:flex items-center gap-2">
-          <span className="chip">Multi-Model</span>
-          <span className="chip">Search-Grounded</span>
-          <span className="chip">Edge Streaming</span>
+        {/* Capability chips */}
+        <div className="flex items-center gap-2 overflow-x-auto max-w-[50vw] md:max-w-none md:overflow-visible">
+          <span className="chip whitespace-nowrap">Multi-Model</span>
+          <span className="chip whitespace-nowrap">Search-Grounded</span>
+          <span className="chip whitespace-nowrap">Edge Streaming</span>
         </div>
 
-        {/* Auth menus (unchanged) */}
-        <div className="flex items-center gap-2">
+        {/* Auth menus */}
+        <div className="flex items-center gap-2 flex-shrink-0">
           {user ? <UserMenu user={user} /> : <GuestMenu />}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove overlapping capability badge from layout to keep header clear
- improve header styling and responsiveness with scrollable capability chips
- elevate glass-header visuals with emerald border and subtle shadow

## Testing
- `bun run lint` *(fails: next: command not found)*
- `bun run typecheck` *(fails: cannot find name 'process' and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c64645447c83318908ed9e87bfed0a